### PR TITLE
Fallback to using 'shortcut icon' if available when retrieving favicons

### DIFF
--- a/src/UrlPreview.php
+++ b/src/UrlPreview.php
@@ -158,6 +158,11 @@ class UrlPreview {
 					$site['icon'] = $this->parseImageUrl($this->crawler->getUri(), $link->attr('href'));
 				});
 			}
+			if (empty($site['icon'])) {
+				$this->crawler->filter('link[rel="shortcut icon"]')->each(function($link) use(&$site, $url) {
+					$site['icon'] = $this->parseImageUrl($this->crawler->getUri(), $link->attr('href'));
+				});
+			}
 		} catch (\Exception $e) {
 			// it's fine
 		}


### PR DESCRIPTION
As the title explains, for some sites (facebook, for example) a "shortcut icon" was used as a reference to the actual fav icon image, so I'd added it as a fallback if all other methods for retrieving an icon doesn't work.